### PR TITLE
Speeding up

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -78,10 +78,9 @@ Converter = {
 			this.collection.name = json.info.title;
 			this.collection.describe(json.info.description);
 			this.collection.variables = _.map(swaggerData.sampleDefinitions);
-
 			tree = Helpers.getTreeFromPaths(json);
 			this.createCollectionStructure(swaggerData, tree);
-
+			delete this.collection.variables;
 			result.output.push({
 				type: 'collection',
 				data: this.collection.toJSON(),

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -280,25 +280,30 @@ module.exports = {
 				} else if (thisParams[param].in === 'body') {
 					rDataMode = 'raw';
 					// Use schema if possible want to use swaggerData.sample definitions to resolve
+
 					if (thisParams[param].schema) {
-						thisParams[param].schema.definitions = _.assign(
-							{},
-							swaggerData.sampleDefinitions, // global definitions
-							thisParams[param].schema.definitions // local definitions
-						);
+						var paramschema = thisParams[param].schema;
+						if (paramschema.$ref) {
+							var valuefield = paramschema.$ref.split('/').pop();
+							var newswagger = {
+								$ref: '#/' + valuefield,
+							};
+							newswagger[valuefield] = swaggerData.sampleDefinitions[valuefield];
+						}
 					}
 					try {
 						// Use modified schema faker class to create tags for the body and create a description if it exists
 						jsf.option('alwaysFakeOptionals', 'true');
 
 						if (thisParams[param].schema.$ref) {
-							rData = jsf.generate(thisParams[param].schema);
+							rData = jsf.generate(newswagger);
 							rdescription = rData.description;
 							delete rData.description;
 						}
 					} catch (e) {
 						rData = '// ' + JSON.stringify(thisParams[param].schema);
 					}
+
 					rHeaders += 'Content-Type: application/json\n';
 				} else if (thisParams[param].in === 'formData') {
 					if (thisConsumes.indexOf('application/x-www-form-urlencoded') > -1) {
@@ -337,11 +342,12 @@ module.exports = {
 					var reference = operation['responses']['200']['schema'].$ref;
 
 					if (reference) {
+						var valuefield = reference.split('/').pop();
 						var inputdef = {
 							// create a definitions object to parse and then put back in
-							$ref: reference,
-							definitions: swaggerData['sampleDefinitions'],
+							$ref: '#/' + valuefield,
 						};
+						inputdef[valuefield] = swaggerData['sampleDefinitions'][valuefield];
 
 						jsf.option('alwaysFakeOptionals', 'true');
 						var outdata = jsf.generate(inputdef);
@@ -385,7 +391,7 @@ module.exports = {
 		request.body = new RequestBody(requestBodyJSON);
 
 		item.request = request;
-
+		delete item.responses;
 		return item;
 	},
 


### PR DESCRIPTION
Before basically it had been crawling through the entire spec and then adding those spec objects to postman even though those are not needed at that point. So I made it so it only passes the object itself into schema faker, since everything is already dereferenced. And after they are used the definitions are deleted so they will not be added to the postman collections. 